### PR TITLE
Fix set default node command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,5 +42,5 @@
   shell: . /etc/bashrc.node.sh; nvm install {{item}}
   with_items: node_versions
 
-- name: st the default node version
-  shell: . /etc/bashrc.node.sh; nvm nvm alias default {{default_node_version}}
+- name: set the default node version
+  shell: . /etc/bashrc.node.sh; nvm alias default {{default_node_version}}


### PR DESCRIPTION
Just a small change to correct a typo in the command which configures the default node version.
